### PR TITLE
Silence various -fsanitize=shift-base

### DIFF
--- a/src/fingerprint.c
+++ b/src/fingerprint.c
@@ -128,12 +128,12 @@ typedef struct table_s
  */
 static uint4 simplehash(const char *p, int len)
 {
-    sint4 h = len * 13;
+    uint4 h = len * 13;
     while (*p)
     {
         h = (h << 5) - h + *p++;
     }
-    return (uint4) h;
+    return h;
 }
 
 /* increases frequency of ngram(p,len) */

--- a/src/utf8misc.c
+++ b/src/utf8misc.c
@@ -61,7 +61,7 @@ const char *utf8_next_char(const char *str)
          * if the first bit of the current char is 1 then *str is an escape
          * character
          */
-        char escape_char = ((*str & WEIGHT_MASK) << 1);
+        unsigned char escape_char = ((*str & WEIGHT_MASK) << 1);
 
         /* 
          * and we use it to count (by bit translation) following characters
@@ -99,7 +99,7 @@ int utf8_charcopy(const char *str, char *dest)
          * then str[pointer] is an escape character and we use it to count
          * following characters (only the weightest part)
          */
-        char escape_char = ((str[pointer] & WEIGHT_MASK) << 1);
+        unsigned char escape_char = ((str[pointer] & WEIGHT_MASK) << 1);
 
         /* 
          * every step, we move the byte of 1 bit left, when first bit is 0,
@@ -138,7 +138,7 @@ int utf8_issame(char *lex, char *key, int len)
              * (only the weightest part)
              */
 
-            char escape_char = ((key[pointer] & WEIGHT_MASK) << 1);
+            unsigned char escape_char = ((key[pointer] & WEIGHT_MASK) << 1);
 
             while (escape_char & ESCAPE_MASK && key[pointer] == lex[pointer])
             {


### PR DESCRIPTION
...that were observed with a UBSan LibreOffice build, when opening LibreOffice's
writerfilter/qa/cppunittests/rtftok/data/pass/EDB-18940-1.rtf.  (Downstream
patch at <https://cgit.freedesktop.org/libreoffice/core/commit/
?id=67141d8331f9cb85751a4747986774b53b7f4a77> "external/libexttextcat: Silence
various -fsanitize=shift-base".)