### PR TITLE
Handle out of memory by exiting instead of segfaulting

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -42,6 +42,12 @@
 #include <ctype.h>
 #include "common_impl.h"
 
+void outofmem(void)
+{
+    fprintf(stderr, "libexttextcat: Out of memory\n");
+    exit(1);
+}
+
 extern char *wg_getline(char *line, int size, FILE * fp)
 {
     char *p;

--- a/src/common.h
+++ b/src/common.h
@@ -77,6 +77,36 @@ extern "C"
                             const char *destlimit);
     extern char *wg_trim(char *dest, const char *src);
 
+    void outofmem(void);
+
+    static inline void *xmalloc(size_t size)
+    {
+        void *ret = malloc(size);
+        if (ret == NULL)
+            outofmem();
+        return ret;
+    }
+
+    static inline void *xcalloc(size_t nmemb, size_t size)
+    {
+        void *ret = calloc(nmemb, size);
+        if (ret == NULL)
+            outofmem();
+        return ret;
+    }
+
+    static inline void *xrealloc(void *ptr, size_t size)
+    {
+        void *ret = realloc(ptr, size);
+        if (ret == NULL)
+            outofmem();
+        return ret;
+    }
+
+#define malloc(size) xmalloc(size)
+#define calloc(nmemb, size) xcalloc(nmemb, size)
+#define realloc(ptr, size) xrealloc(ptr, size)
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Dovecot limits process VSZ by default, and we noticed that libexttextcat crashes when it can't allocate memory. Segfaulting doesn't make it very clear why the failure happened, so would be nice to get some kind of an error message printed. Here's the simplest patch I thought of to fix it.
