### PR TITLE
Fix type mismatch between declaration and definition

### DIFF
--- a/src/wg_mempool.c
+++ b/src/wg_mempool.c
@@ -83,7 +83,7 @@ static void addblock(mempool_t * h)
 }
 
 
-extern void *wgmempool_Init(size_t blocksize, size_t maxstrsize)
+extern void *wgmempool_Init(uint4 blocksize, size_t maxstrsize)
 {
     mempool_t *result = (mempool_t *) malloc(sizeof(mempool_t));
 


### PR DESCRIPTION
Compiling with LTO otherwise fails with:

```
wg_mempool.h:91:18: error: type of 'wgmempool_Init' does not match original declaration [-Werror=lto-type-mismatch]
   91 |     extern void *wgmempool_Init(uint4 blocksize, size_t maxstrsize);
      |                  ^
wg_mempool.c:86:14: note: type mismatch in parameter 1
   86 | extern void *wgmempool_Init(size_t blocksize, size_t maxstrsize)
      |              ^
wg_mempool.c:86:14: note: type 'size_t' should match type 'uint4'
wg_mempool.c:86:14: note: 'wgmempool_Init' was previously declared here
wg_mempool.c:86:14: note: code may be misoptimized unless '-fno-strict-aliasing' is used
```